### PR TITLE
Use network specific critical flag

### DIFF
--- a/server.js
+++ b/server.js
@@ -99,9 +99,10 @@ app.post('/push-release/:tag/:commit', validateRelease, handleAsync(async functi
 	}
 
 	const network = (await getNetwork()).toLowerCase();
-	let forkSupported = parseInt(meta.forks[network], 10);
+	const networkSettings = meta.networks[network];
+	let forkSupported = parseInt(networkSettings.forkBlock, 10);
 	if (isNaN(forkSupported)) {
-		console.warn(`Invalid fork data for ${network}: '${meta.forks[network]}', assuming 0`);
+		console.warn(`Invalid fork data for ${network}: '${networkSettings.forkBlock}', assuming 0`);
 		forkSupported = 0;
 	}
 
@@ -120,10 +121,10 @@ app.post('/push-release/:tag/:commit', validateRelease, handleAsync(async functi
 	const registryAddress = await api.parity.registryAddress();
 	const registry = api.newContract(RegistrarABI, registryAddress);
 
-	console.log(`Registering release: 0x000000000000000000000000${commit}, ${forkSupported}, ${tracks[track]}, ${semver}, ${meta.critical}`);
+	console.log(`Registering release: 0x000000000000000000000000${commit}, ${forkSupported}, ${tracks[track]}, ${semver}, ${networkSettings.critical}`);
 
 	const operationsAddress = await registry.instance.getAddress.call({}, [operationsContract, 'A']);
-	await sendTransaction(OperationsABI, operationsAddress, 'addRelease', [`0x000000000000000000000000${commit}`, forkSupported, tracks[track], semver, meta.critical]);
+	await sendTransaction(OperationsABI, operationsAddress, 'addRelease', [`0x000000000000000000000000${commit}`, forkSupported, tracks[track], semver, networkSettings.critical]);
 
 	// Return the response
 	return `RELEASE: ${commit}/${track}/${meta.track}/${forkSupported}`;
@@ -214,7 +215,6 @@ async function readParityMetadata (commit) {
 
 		return {
 			version: parsed.package.version,
-			critical: parsed.package.critical || false,
 			...parsed.package.metadata
 		};
 	} catch (err) {

--- a/server.js
+++ b/server.js
@@ -212,6 +212,16 @@ async function readParityMetadata (commit) {
 	try {
 		const metaFile = await fetchFile(commit, '/util/version/Cargo.toml');
 		const parsed = toml.parse(metaFile);
+		const metadata = parsed.package.metadata;
+
+		if (metadata.networks === undefined) {
+			// backwards compatibility with legacy format
+			metadata.networks = metadata.forks;
+			const critical = parsed.package.critical || false;
+			for (let network in metadata.forks) {
+				metadata.networks[network] = { forkBlock: metadata.forks[network], critical: critical };
+			}
+		}
 
 		return {
 			version: parsed.package.version,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -14,7 +14,7 @@ const server = new ServerMock({ host: 'localhost', port: 8545 });
 describe('push-release', () => {
 	it('should reject invalid secret', async () => {
 		let res = await request(app => app
-			.post('/push-release/v1.9.5/8b749367fd5fea897cee98bd892fff1ce90f8260')
+			.post('/push-release/v1.9.5/e92e6c4f796f6338b2a99c499a0fe9c238f2d84f')
 			.type('form')
 			.send({ secret: 'xxx' })
 		);
@@ -26,7 +26,7 @@ describe('push-release', () => {
 	it('should gently reject invalid tags', async () => {
 		const test = async tag => {
 			let res = await request(app => app
-				.post(`/push-release/${tag}/8b749367fd5fea897cee98bd892fff1ce90f8260`)
+				.post(`/push-release/${tag}/e92e6c4f796f6338b2a99c499a0fe9c238f2d84f`)
 				.type('form')
 				.send({ secret })
 			);
@@ -66,7 +66,7 @@ describe('push-release', () => {
 		});
 
 		let res = await request(app => app
-			.post('/push-release/v1.7.13/c060d9584dae34e0e215f061bd61b2ebd375956b')
+			.post('/push-release/v1.7.13/e92e6c4f796f6338b2a99c499a0fe9c238f2d84f')
 			.type('form')
 			.send({ secret })
 		);
@@ -75,7 +75,7 @@ describe('push-release', () => {
 		// Register in operations
 		expect(requests[3].method).to.equal('eth_sendTransaction');
 		expect(requests[3].params).to.deep.equal([{
-			data: '0x932ab270000000000000000000000000c060d9584dae34e0e215f061bd61b2ebd375956b00000000000000000000000000000000000000000000000000000000004d50f800000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000010a000000000000000000000000000000000000000000000000000000000000000000',
+			data: '0x932ab270000000000000000000000000e92e6c4f796f6338b2a99c499a0fe9c238f2d84f000000000000000000000000000000000000000000000000000000000064b54000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000010c000000000000000000000000000000000000000000000000000000000000000000',
 			from: '0x0066ac7a4608f350bf9a0323d60dde211dfb27c0',
 		gasPrice,
 			to: '0x0000000000000000bf900003d60dde211dfb0000'
@@ -91,7 +91,7 @@ describe('push-build', () => {
 			.send({
 				secret: 'xxx',
 				sha3: 'a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
-				commit: '8b749367fd5fea897cee98bd892fff1ce90f8260',
+				commit: 'e92e6c4f796f6338b2a99c499a0fe9c238f2d84f',
 				filename: 'parity'
 			})
 		);
@@ -108,7 +108,7 @@ describe('push-build', () => {
 				.send({
 					secret,
 					sha3: 'a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
-					commit: '8b749367fd5fea897cee98bd892fff1ce90f8260',
+					commit: 'e92e6c4f796f6338b2a99c499a0fe9c238f2d84f',
 					filename: 'parity'
 				})
 			);
@@ -128,7 +128,7 @@ describe('push-build', () => {
 			.send({
 				secret,
 				sha3: 'a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
-				commit: '8b749367fd5fea897cee98bd892fff1ce90f8260',
+				commit: 'e92e6c4f796f6338b2a99c499a0fe9c238f2d84f',
 				filename: 'parity'
 			})
 		);
@@ -144,7 +144,7 @@ describe('push-build', () => {
 			.send({
 				secret,
 				sha3: 'a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
-				// commit: '8b749367fd5fea897cee98bd892fff1ce90f8260',
+				// commit: 'e92e6c4f796f6338b2a99c499a0fe9c238f2d84f',
 				filename: 'parity'
 			})
 		);
@@ -174,7 +174,7 @@ describe('push-build', () => {
 			.send({
 				secret,
 				sha3: 'a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
-				commit: 'c060d9584dae34e0e215f061bd61b2ebd375956b',
+				commit: 'e92e6c4f796f6338b2a99c499a0fe9c238f2d84f',
 				filename: 'parity'
 			})
 		);
@@ -191,7 +191,7 @@ describe('push-build', () => {
 		// Build registration
 		expect(requests[4].method).to.equal('eth_sendTransaction');
 		expect(requests[4].params).to.deep.equal([{
-			data: '0x793b0efb000000000000000000000000c060d9584dae34e0e215f061bd61b2ebd375956b7838365f36342d756e6b6e6f776e2d6c696e75782d676e750000000000000000a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
+			data: '0x793b0efb000000000000000000000000e92e6c4f796f6338b2a99c499a0fe9c238f2d84f7838365f36342d756e6b6e6f776e2d6c696e75782d676e750000000000000000a00ead491c0e47efe4abefeb27ddc6ed8d1ea4daa43683d8e349e1e7459b74ba',
 			from: '0x0066ac7a4608f350bf9a0323d60dde211dfb27c0',
 			gasPrice,
 			to: '0x0000000000000000bf900003d60dde211dfb0000'

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -10,10 +10,7 @@ const app = require('../server');
 const secret = 'test';
 const gasPrice = '0x4f9aca000';
 
-const server = new ServerMock({
-	host: 'localhost',
-	port: 8545
-});
+const server = new ServerMock({ host: 'localhost', port: 8545 });
 
 describe('push-release', () => {
 	async function pushRelease(commit, network, forkBlock, critical) {
@@ -33,9 +30,7 @@ describe('push-release', () => {
 		let res = await request(app => app
 			.post(`/push-release/v1.7.13/${commit}`)
 			.type('form')
-			.send({
-				secret
-			})
+			.send({ secret })
 		);
 
 		const expectedCritical = critical ? '1' : '0';
@@ -56,9 +51,7 @@ describe('push-release', () => {
 		let res = await request(app => app
 			.post('/push-release/v1.9.5/e92e6c4f796f6338b2a99c499a0fe9c238f2d84f')
 			.type('form')
-			.send({
-				secret: 'xxx'
-			})
+			.send({ secret: 'xxx' })
 		);
 
 		expect(res).to.have.status(401);
@@ -70,9 +63,7 @@ describe('push-release', () => {
 			let res = await request(app => app
 				.post(`/push-release/${tag}/e92e6c4f796f6338b2a99c499a0fe9c238f2d84f`)
 				.type('form')
-				.send({
-					secret
-				})
+				.send({ secret })
 			);
 
 			expect(res).to.have.status(202);
@@ -87,9 +78,7 @@ describe('push-release', () => {
 		let res = await request(app => app
 			.post('/push-release/v1.7.13/8b749367')
 			.type('form')
-			.send({
-				secret
-			})
+			.send({ secret })
 		);
 
 		expect(res).to.have.status(400);
@@ -195,9 +184,7 @@ describe('push-build', () => {
 			path: '/',
 			reply: {
 				status: 200,
-				headers: {
-					'content-type': 'application/json'
-				},
+				headers: { 'content-type': 'application/json' },
 				body: parityRespond(requests)
 			}
 		});
@@ -234,7 +221,7 @@ describe('push-build', () => {
 });
 
 // Overcoming a bug in chai-http: https://github.com/chaijs/chai-http/issues/156
-function request(fn) {
+function request (fn) {
 	return new Promise((resolve, reject) => {
 		return fn(chai.request(app)).end((err, res) => {
 			if (res) {
@@ -246,14 +233,12 @@ function request(fn) {
 	});
 }
 
-function parityRespond(requests, chain) {
+function parityRespond (requests, chain) {
 	return (req) => {
 		requests.push(req.body);
 
 		let result = null;
-		const {
-			method
-		} = req.body;
+		const { method } = req.body;
 
 		if (method === 'parity_chain') {
 			result = (chain === undefined) ? 'kovan' : chain;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -108,6 +108,11 @@ describe('push-release', () => {
 		await pushRelease(kovanTrueCommit, 'kovan', 6600000, true);
 		await pushRelease(kovanTrueCommit, 'ropsten', 10, false);
 	});
+
+	it('should be backwards compatible with global critical flag', async () => {
+		const legacyCommit = 'adc3457a893bac241c00e897df702e9bbc1468d9';
+		await pushRelease(legacyCommit, 'kovan', 6600000, false);
+	});
 });
 
 describe('push-build', () => {


### PR DESCRIPTION
rel https://github.com/paritytech/parity/pull/8821.

Allows specifying whether a given release is critical per network.